### PR TITLE
Updated regex matching to use raw strings

### DIFF
--- a/ipbench2/src/ipbench.py
+++ b/ipbench2/src/ipbench.py
@@ -226,7 +226,7 @@ class IpbenchTestClient:
         initial_content = buffer + self.socket.recv(128)
         clenline = copy(initial_content).decode('ascii', errors='ignore')
         newline = clenline.find('\n')
-        r = re.match("Content-length: (\d+)", clenline[:newline])
+        r = re.match(r"Content-length: (\d+)", clenline[:newline])
         if r.group(1) is None:
             raise IpBenchError("Invalid Content-length")
         content_length = int(r.group(1))

--- a/ipbench2/src/ipbenchd.py
+++ b/ipbench2/src/ipbenchd.py
@@ -219,7 +219,7 @@ class IpbenchClient:
         while (1):
             line_in = self.readline().strip()
 
-            cmd = re.match("\S*", line_in).group(0)
+            cmd = re.match(r"\S*", line_in).group(0)
             if cmd is None:
                 self.send(str_status(500))
                 continue
@@ -260,7 +260,7 @@ class IpbenchClient:
             if line_in == "QUIT":
                 return ("ERROR", (222, "Come back soon!"))
 
-            cmd = re.match("(\S+)", line_in)
+            cmd = re.match(r"(\S+)", line_in)
             if cmd is None:
                 self.send(str_status(500))
                 continue
@@ -291,7 +291,7 @@ class IpbenchClient:
             if line_in == "QUIT":
                 return ("ERROR", (222, "Come back soon!"))
 
-            rematch = re.match("(\w+) ([\s\w]+)", line_in)
+            rematch = re.match(r"(\w+) ([\s\w]+)", line_in)
             if rematch is None:
                 self.send(str_status(500))
                 continue
@@ -315,7 +315,7 @@ class IpbenchClient:
                             if line_in == "QUIT":
                                 return ("ERROR", (222, "Come back soon!"))
 
-                            rematch = re.match("(\w+) (..*)", line_in)
+                            rematch = re.match(r"(\w+) (..*)", line_in)
                             if rematch is None:
                                 self.send(str_status(500))
                                 continue
@@ -364,7 +364,7 @@ class IpbenchClient:
             if line_in == "QUIT":
                 return ("ERROR", (222, "Come back soon!"))
 
-            rematch = re.match("(\w+)", line_in)
+            rematch = re.match(r"(\w+)", line_in)
             if rematch is None:
                 self.send(str_status(500))
                 continue
@@ -472,7 +472,7 @@ class IpbenchTarget(IpbenchClient):
             if line_in == "QUIT":
                 return ("ERROR", (222, "Come back soon!"))
 
-            rematch = re.match("(\w+)", line_in)
+            rematch = re.match(r"(\w+)", line_in)
             if rematch is None:
                 self.send(str_status(500))
                 continue
@@ -503,7 +503,7 @@ class IpbenchTarget(IpbenchClient):
                             os._exit(0)
                         if line_in == "QUIT":
                             return ("ERROR", (222, "Come back soon!"))
-                        rematch = re.match("(\w+)", line_in)
+                        rematch = re.match(r"(\w+)", line_in)
                         if rematch is None:
                             self.send(str_status(500))
                             continue


### PR DESCRIPTION
In python3.12 and above, backslashes which aren't part of escape characters cause SyntaxWarnings, and in future they will become SyntaxErrors (https://docs.python.org/3/library/re.html). Backslashes are needed in regex matching. The recommended workaround is to supply raw strings to regex matches. This PR changes the regex matches present in ipbench's python components to use raw strings.