### PR TITLE
Fix plugin name regex truncation and inverted debug ternaries

### DIFF
--- a/ipbench2/src/ipbenchd.py
+++ b/ipbench2/src/ipbenchd.py
@@ -291,7 +291,7 @@ class IpbenchClient:
             if line_in == "QUIT":
                 return ("ERROR", (222, "Come back soon!"))
 
-            rematch = re.match(r"(\w+) ([\s\w]+)", line_in)
+            rematch = re.match(r"(\w+) ([\s\w-]+)", line_in)
             if rematch is None:
                 self.send(str_status(500))
                 continue

--- a/ipbench2/src/pymod/ipbench.c
+++ b/ipbench2/src/pymod/ipbench.c
@@ -245,7 +245,7 @@ int unmarshall(int clientid, char *data, int len, int valid)
 	int sts;
 	char *ret_data;
 	dbprintf("[unmarshall] data for client %d \"%s\" [len %d] [%s]\n", 
-		 clientid, data, len, valid ? "invalid" : "valid");
+		 clientid, data, len, valid ? "valid" : "invalid");
 	
 	sts = ipbench_plugin->unmarshall(data, len, &ret_data,
 					 &client_data[clientid].size);
@@ -261,7 +261,7 @@ int unmarshall(char *data, int len, int valid)
 	int sts;
 	char *ret_data;
 	dbprintf("[unmarshall] data for target \"%s\" [len %d] [%s]\n", 
-		 data, len, valid ? "invalid" : "valid");
+		 data, len, valid ? "valid" : "invalid");
 	sts = ipbench_plugin->unmarshall(data, len, &ret_data, &target_data.size);
 	target_data.data = ret_data;
 	target_data.valid = valid;


### PR DESCRIPTION
**Regex**

When running `benchmark.py` from sDDF `echo_server`, the 'latency-check' argument gets truncated to 'latency' and matches different columns in the output CSV data. e.g. you might end up with Send_Throughput matching with Average_RTT and end up wondering where all your packets are gone (totally not speaking from experience :smiley: ) 

**Ternaries**

The conditional strings appear to be inverted.